### PR TITLE
fix: mongo-express image rollback

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
       - mongodb:/data/db
 
   mongo-express:
-    image: mongo-express
+    image: mongo-express:1.0.0-alpha.4
     restart: always
     ports:
       - 8081:8081

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,7 +33,6 @@ services:
       MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME}
       MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD}
     volumes:
-      - ./upgrader/mongodb_init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
       - mongodb:/data/db
 
   mongo-express:

--- a/upgrader/mongodb_init.js
+++ b/upgrader/mongodb_init.js
@@ -1,2 +1,0 @@
-db.createCollection('monsters');
-db.createCollection('status');


### PR DESCRIPTION
The new mongo-express image (e8f1096fc88d) is broken, not possible
delete objects of a collection and also import data.
[https://github.com/mongo-express/mongo-express-docker/issues/103](vscode-file://vscode-app/c:/Users/rapha/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)