### PR TITLE
feat: add healthcheck to api and mongodb

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -5,7 +5,13 @@ WORKDIR /app
 COPY main.py main.py
 COPY requirements.txt requirements.txt
 COPY templates/ templates/
+COPY docker-entrypoint.sh /
 
-RUN ["python3", "-m", "pip", "install", "-r", "requirements.txt"]
+RUN apt-get update && \
+    apt-get install -y curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+RUN python3 -m pip install -r requirements.txt
+RUN chmod +x /docker-entrypoint.sh
 
-ENTRYPOINT [ "python3", "-m", "uvicorn", "main:app", "--host", "0.0.0.0" ]
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/api/docker-entrypoint.sh
+++ b/api/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+python3 -m uvicorn main:app --host "0.0.0.0" --port "80"

--- a/api/main.py
+++ b/api/main.py
@@ -30,6 +30,12 @@ async def monster(request: Request):
     return templates.TemplateResponse("monster_info.html", {"request": request})
 
 
+@app.get("/api/health")
+async def healthz():
+    status = { "healthy": "true" }
+    return JSONResponse(content=status)
+
+
 @app.get("/api/monsters", response_model=List[dict])
 async def get_monsters(
     name: Optional[str] = Query(

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,15 +1,24 @@
-version: '3.1'
+version: '3.8'
 
 services:
+
+  autoheal:
+    image: willfarrell/autoheal:latest
+    restart: always
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
 
   api:
     image: api
     build: ./api
     restart: always
+    labels:
+      - autoheal=true
     depends_on:
-      - upgrader
+      mongo:
+        condition: service_healthy
     ports:
-      - 80:8000
+      - 80:80
     environment:
       MONGODB_URL:
         "mongodb://\
@@ -17,6 +26,12 @@ services:
         ${MONGO_ROOT_PASSWORD:-changeme}@\
         ${MONGO_HOST:-mongo}:\
         ${MONGO_PORT:-27017}/"
+    healthcheck:
+      test: curl --fail http://localhost/api/health || exit 1
+      interval: 10s
+      timeout: 1s
+      retries: 3
+      start_period: 10s
 
   upgrader:
     image: upgrader
@@ -32,10 +47,13 @@ services:
       API_KEY: ${API_KEY}
       LOG_LEVEL: "${LOG_LEVEL:-INFO}"
     depends_on:
-      - mongo
+      mongo:
+        condition: service_healthy
 
   mongo:
     image: mongo
+    labels:
+      - autoheal=true
     restart: always
     ports:
       - ${MONGO_PORT:-27017}:${MONGO_PORT:-27017}
@@ -44,7 +62,19 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD:-changeme}
     volumes:
       - mongodb:/data/db
-    
+    healthcheck:
+      test: 
+        - CMD
+        - mongosh
+        - --eval
+        - db.runCommand('ping').ok
+        - localhost:27017/test
+        - --quiet
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 10s
+
   mongo-express:
     image: mongo-express:1.0.0-alpha.4
     restart: always
@@ -60,7 +90,8 @@ services:
       ME_CONFIG_BASICAUTH_USERNAME: ${ME_CONFIG_BASICAUTH_USERNAME:-admin}
       ME_CONFIG_BASICAUTH_PASSWORD: ${ME_CONFIG_BASICAUTH_PASSWORD:-pass}
     depends_on:
-      - mongo
+      mongo:
+        condition: service_healthy
 
 volumes:
   mongodb:


### PR DESCRIPTION
If api or mongo microservice return 3 healthchecks failed, the new microservice, autoheal, will restart the PODs.
Now if the mongo isn't healthy, the other microservices that have dependence on it will wait for a healthy status.